### PR TITLE
Allowing Environmental Auth

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,9 @@ Usage
 
     table = dynamo.table(TABLE_NAME, (ACCESS_KEY, SECRET_ACCESS_KEY))
 
+    # Or, if you have AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY defined as
+    # environment variables, you can do:
+    table = dynamo.table(TABLE_NAME)
 
 Writing is simple::
 

--- a/dynamo.py
+++ b/dynamo.py
@@ -112,10 +112,8 @@ class Item(object):
 
 def table(name, auth=None, eager=True):
     """Returns a given table for the given user."""
-    if auth:
-        dynamodb = boto.connect_dynamodb(*auth)
-    else:
-        dynamodb = boto.connect_dynamodb()
+    auth = auth or []
+    dynamodb = boto.connect_dynamodb(*auth)
 
     table = dynamodb.get_table(name)
     return Table(table=table, eager=eager)
@@ -123,9 +121,7 @@ def table(name, auth=None, eager=True):
 
 def tables(auth=None, eager=True):
     """Returns a list of tables for the given user."""
-    if auth:
-        dynamodb = boto.connect_dynamodb(*auth)
-    else:
-        dynamodb = boto.connect_dynamodb()
+    auth = auth or []
+    dynamodb = boto.connect_dynamodb(*auth)
 
     return [table(t, auth, eager=eager) for t in dynamodb.list_tables()]

--- a/dynamo.py
+++ b/dynamo.py
@@ -110,14 +110,22 @@ class Item(object):
         return key in self.item
 
 
-def table(name, auth, eager=True):
+def table(name, auth=None, eager=True):
     """Returns a given table for the given user."""
-    dynamodb = boto.connect_dynamodb(*auth)
+    if auth:
+        dynamodb = boto.connect_dynamodb(*auth)
+    else:
+        dynamodb = boto.connect_dynamodb()
+
     table = dynamodb.get_table(name)
     return Table(table=table, eager=eager)
 
 
-def tables(auth, eager=True):
+def tables(auth=None, eager=True):
     """Returns a list of tables for the given user."""
-    dynamodb = boto.connect_dynamodb(*auth)
+    if auth:
+        dynamodb = boto.connect_dynamodb(*auth)
+    else:
+        dynamodb = boto.connect_dynamodb()
+
     return [table(t, auth, eager=eager) for t in dynamodb.list_tables()]


### PR DESCRIPTION
This lets us authenticate to DynamoDB using our environment credentials
(through boto), eg:

```
AWS_ACCESS_KEY_ID, and AWS_SECRET_ACCESS_KEY
```
