### PR TITLE
Fix Python 3 issue, use str instead of basestring

### DIFF
--- a/dynamo.py
+++ b/dynamo.py
@@ -30,7 +30,7 @@ class Table(object):
 
     def __getitem__(self, key):
         try:
-            if isinstance(key, (basestring, Number)):
+            if isinstance(key, (str, Number)):
                 key = [key]
             i = self.table.get_item(*key)
             i = self.item(i)
@@ -45,7 +45,7 @@ class Table(object):
             return default
 
     def __setitem__(self, key, values):
-        if isinstance(key, (basestring, Number)):
+        if isinstance(key, (str, Number)):
             key = [key]
         i = self.table.new_item(*key, attrs=values)
         i = self.item(i)


### PR DESCRIPTION
Hey @kennethreitz!

Just a small PR to fix an issue I got trying to use this with Python3.

```
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/opt/conda/lib/python3.5/site-packages/dynamo.py", line 48, in __setitem__
    if isinstance(key, (basestring, Number)):
NameError: name 'basestring' is not defined
```

This was pretty easy to fix, just forked the repo and ran:

```bash
2to3 -wn dynamo.py
```